### PR TITLE
gateway server to run in beforeall hook

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "express-gateway-plugin-rewrite",
-  "version": "1.1.2",
+  "version": "0.0.0-development",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/plugin.test.js
+++ b/plugin.test.js
@@ -1,12 +1,27 @@
 const axios = require('axios').default;
 const path = require('path');
-const gateway = require('express-gateway');
 const express = require('express');
+const proc = require('child_process')
 
 let Application = undefined;
 let axiosInstance = undefined;
+let gatewayTestInstance = undefined;
 
-beforeAll((done) => {
+function startServer () {
+  return new Promise(
+    (resolve, reject) => {
+      server = proc.spawn('node', ['./test/server.js']);
+      server.stdout.on('data', (data)=>{
+        const chk = /gateway http server listening on/g;
+        if (chk.test(data)) {
+          resolve('server started');          
+        } 
+    });
+  });  
+}
+
+beforeAll( async () => {
+  await startServer();
   axiosInstance = axios.create({
     baseURL: 'http://localhost:8080/',
     validateStatus: (status) => status < 400
@@ -19,11 +34,12 @@ beforeAll((done) => {
   app.get('/src/js/*', hello);
   app.get('/api/v1/*', hello)
 
-  Application = app.listen(8081, done);
+  Application = app.listen(8081);
 
 });
 
 afterAll((done) => {
+  server.kill('SIGTERM');
   Application.close(done);
 })
 


### PR DESCRIPTION
* fix for starting the gateway server manually before the `npm test`
* `npm test` will just start the server in beforeall() hook